### PR TITLE
Use hasha module for MD5 hash generate process

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/erm0l0v/webpack-md5-hash",
   "dependencies": {
-    "md5": "^2.0.0"
+    "hasha": "^2.2.0"
   },
   "devDependencies": {
     "argparse": "^1.0.4",

--- a/plugin/webpack_md5_hash.js
+++ b/plugin/webpack_md5_hash.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var md5 = require("md5");
+var hasha = require("hasha");
 
 function compareModules(a,b) {
     if (a.resource < b.resource) {
@@ -29,7 +29,7 @@ WebpackMd5Hash.prototype.apply = function(compiler) {
     compiler.plugin("compilation", function(compilation) {
         compilation.plugin("chunk-hash", function(chunk, chunkHash) {
             var source = chunk.modules.sort(compareModules).map(getModuleSource).reduce(concatenateSource, ''); // we provide an initialValue in case there is an empty module source. Ref: http://es5.github.io/#x15.4.4.21
-            var chunk_hash = md5(source);
+            var chunk_hash = hasha(source, { algorithm: 'md5' });
             chunkHash.digest = function () {
                 return chunk_hash;
             };


### PR DESCRIPTION
Using [hasha](https://github.com/sindresorhus/hasha) I have achieved generate time drop from 2.5s to 700ms. This is probably because hasha internally uses native crypto module instead of custom implementation from md5 module.

Would you consider using this module? I suppose this needs to be additionally checked because of Node support.
