### PR TITLE
Remove Chunk.modules deprecation warning

### DIFF
--- a/plugin/webpack_md5_hash.js
+++ b/plugin/webpack_md5_hash.js
@@ -28,7 +28,8 @@ function WebpackMd5Hash () {
 WebpackMd5Hash.prototype.apply = function(compiler) {
     compiler.plugin("compilation", function(compilation) {
         compilation.plugin("chunk-hash", function(chunk, chunkHash) {
-            var source = chunk.modules.sort(compareModules).map(getModuleSource).reduce(concatenateSource, ''); // we provide an initialValue in case there is an empty module source. Ref: http://es5.github.io/#x15.4.4.21
+            var modules = chunk.mapModules ? chunk.mapModules(getModuleSource) : chunk.modules.map(getModuleSource);
+            var source = modules.sort(sortById).reduce(concatenateSource, ''); // we provide an initialValue in case there is an empty module source. Ref: http://es5.github.io/#x15.4.4.21
             var chunk_hash = md5(source);
             chunkHash.digest = function () {
                 return chunk_hash;


### PR DESCRIPTION
Fix deprecation warning: `DeprecationWarning: Chunk.modules is deprecated. Use Chunk.getNumberOfModules/mapModules/forEachModule/containsModule instead.`

The fix is the same one used in `webpack-chunk-hash` ([see code here](https://github.com/alexindigo/webpack-chunk-hash/commit/6b44e69418510b997e89bc2e84c7bfbdc05d7d30)).